### PR TITLE
Fixed threading issue with UI

### DIFF
--- a/src/building/Building.tsx
+++ b/src/building/Building.tsx
@@ -6,9 +6,10 @@ interface BuildingProps {
     numFloors: number;
     windowsPerFloor: number;
     currentFloor: number;
+    state: string;
 }
 
-export function Building({numFloors, windowsPerFloor, currentFloor}: BuildingProps): React.ReactElement {
+export function Building({numFloors, windowsPerFloor, currentFloor, state}: BuildingProps): React.ReactElement {
 
     const floor: React.ReactElement[] = [];
     for (let i = 0; i < numFloors; i++) {
@@ -18,6 +19,7 @@ export function Building({numFloors, windowsPerFloor, currentFloor}: BuildingPro
                 floor={i + 1}
                 windowsPerFloor={windowsPerFloor}
                 currentFloor={currentFloor}
+                state={state}
             />
         )
     }

--- a/src/building/FloorWindows.tsx
+++ b/src/building/FloorWindows.tsx
@@ -5,12 +5,21 @@ interface FloorWindowsProps {
     floor: number,
     windowsPerFloor: number,
     currentFloor: number
+    state: string,
 }
 
-export function FloorWindows({floor, windowsPerFloor, currentFloor}: FloorWindowsProps): React.ReactElement {
+export function FloorWindows({floor, windowsPerFloor, currentFloor, state}: FloorWindowsProps): React.ReactElement {
 
     const getWindowColor = (floor: number, windowIndex: number): string => {
-        return currentFloor === floor && windowIndex === 3 ? 'black' : 'white';
+
+        // elevator
+        if (windowIndex === 3 && currentFloor === floor) {
+            if (state === 'IDLE' || state === 'ARRIVED') return 'black';
+
+            return 'grey'
+        }
+
+        return 'white';
     }
 
     const windows: React.ReactElement[] = [];
@@ -28,5 +37,6 @@ export function FloorWindows({floor, windowsPerFloor, currentFloor}: FloorWindow
         )
     }
 
-    return (<Grid container minWidth='24em'><Box sx={{display: 'flex', border: 1, borderColor: '#4e5052'}}>{windows}</Box></Grid>)
+    return (<Grid container minWidth='24em'><Box
+        sx={{display: 'flex', border: 1, borderColor: '#4e5052'}}>{windows}</Box></Grid>)
 }


### PR DESCRIPTION
The UI would spin off multiple timers (threads) because `clearTimeout()` was not called correctly. The issue was further complicated because `clearTimeout()` is inside a `useEffect()` and the dependency array was triggering the `useEffect()` at the wrong times. 

The solution was to simplify the logic in each state change, remove some of the state like `nextFloor` and derive state where possible rather than store it.

The result of this PR is:
1. The elevator moves one floor at a time until it reaches the destination
2. The elevator turns grey while in route
3. It no longer cares about current direction. It will move to whatever is closest. I hope to change it back to using current direction in a future PR.